### PR TITLE
  feat: React Router DOM 초기 설정 및 기본 라우팅 구조 구성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,43 +1,12 @@
-import { useState } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
+import { Outlet } from 'react-router-dom';
 
 function App() {
-  const [count, setCount] = useState(0);
-
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
-      <div className="flex items-center justify-center space-x-8">
-        <a href="https://vite.dev" target="_blank" rel="noreferrer">
-          <img
-            src={viteLogo}
-            className="h-24 p-2 transition-all duration-300 hover:drop-shadow-[0_0_2em_#646cffaa]"
-            alt="Vite logo"
-          />
-        </a>
-        <a href="https://react.dev" target="_blank" rel="noreferrer">
-          <img
-            src={reactLogo}
-            className="h-24 animate-spin p-2 transition-all duration-300 [animation-duration:20s] hover:drop-shadow-[0_0_2em_#61dafbaa]"
-            alt="React logo"
-          />
-        </a>
-      </div>
-      <h1 className="my-8 text-5xl font-bold">Vite + React</h1>
-      <div className="rounded-lg bg-gray-800 p-8 text-center">
-        <button
-          onClick={() => setCount((count) => count + 1)}
-          className="mb-4 rounded-lg bg-indigo-600 px-4 py-2 text-lg font-medium text-white transition-colors hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-900"
-        >
-          count is {count}
-        </button>
-        <p className="text-gray-400">
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="mt-8 text-gray-500">
-        Click on the Vite and React logos to learn more
-      </p>
+    <div className="p-4">
+      {/* 공통 네비게이션 바 등이 위치할 수 있습니다. */}
+      <main>
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import router from './router';
+import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <RouterProvider router={router} />
+  </StrictMode>
+);

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,0 +1,3 @@
+export default function AdminPage() {
+  return <h1 className="text-3xl font-bold">관리자 화면</h1>;
+}

--- a/src/pages/DisplayPage.tsx
+++ b/src/pages/DisplayPage.tsx
@@ -1,0 +1,3 @@
+export default function DisplayPage() {
+  return <h1 className="text-3xl font-bold">송출 화면</h1>;
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1 className="text-3xl font-bold">홈페이지</h1>;
+}

--- a/src/pages/KioskPage.tsx
+++ b/src/pages/KioskPage.tsx
@@ -1,0 +1,3 @@
+export default function KioskPage() {
+  return <h1 className="text-3xl font-bold">키오스크 화면</h1>;
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,33 @@
+import { createBrowserRouter } from 'react-router-dom';
+import App from './App';
+import HomePage from './pages/HomePage';
+import KioskPage from './pages/KioskPage';
+import AdminPage from './pages/AdminPage';
+import DisplayPage from './pages/DisplayPage';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      {
+        index: true,
+        element: <HomePage />,
+      },
+      {
+        path: 'kiosk',
+        element: <KioskPage />,
+      },
+      {
+        path: 'admin',
+        element: <AdminPage />,
+      },
+      {
+        path: 'display',
+        element: <DisplayPage />,
+      },
+    ],
+  },
+]);
+
+export default router;


### PR DESCRIPTION
  프로젝트의 페이지 이동을 관리하기 위해 `react-router-dom`을 설정하고, 주요 섹션에 대한 기본 
  라우팅 구조를 마련합니다.

  향후 키오스크, 관리자, 송출 화면 등 각 기능 영역을 확장하기 용이하도록 모듈화된 라우팅 시스템의
  기반을 구축했습니다.

  주요 변경 사항:

   * 라우터 설정 파일 추가 (`src/router.tsx`): 모든 라우팅 규칙을 중앙에서 관리하도록
     createBrowserRouter를 사용하여 라우터를 생성했습니다.
   * 기본 페이지 컴포넌트 생성: src/pages 디렉토리를 만들고, 초기 라우트(홈, 키오스크, 관리자,
     송출)에 해당하는 placeholder 페이지들을 추가했습니다.
   * `App.tsx` 리팩터링: App.tsx를 모든 페이지의 공통 상위 레이아웃 역할을 하도록 수정하고, 페이지
     콘텐츠가 렌더링될 위치에 <Outlet>을配置했습니다.
   * `main.tsx` 업데이트: 앱의 진입점에서 RouterProvider를 사용하도록 변경하여 라우팅 시스템을
     활성화했습니다.

  테스트 방법:

   1. 개발 서버를 실행합니다 (pnpm dev).
   2. 브라우저에서 아래 경로로 이동하여 각 페이지의 제목이 올바르게 표시되는지 확인합니다.
       * / → "홈페이지"
       * /kiosk → "키오스크 화면"
       * /admin → "관리자 화면"
       * /display → "송출 화면"