### PR TITLE
feat: 고해상도 얼굴 인식 및 정사각형 UI 지원

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
+    "dev": "pnpm run prebuild && vite",
+    "prebuild": "rm -rf public/models && mkdir -p public/models && cp node_modules/@mediapipe/tasks-vision/wasm/* public/models && curl -L https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task -o public/models/face_landmarker.task",
+    "build": "pnpm run prebuild && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/src/components/FaceCapture.tsx
+++ b/src/components/FaceCapture.tsx
@@ -2,160 +2,196 @@ import { useRef, useEffect, useState, useCallback } from 'react';
 import Webcam from 'react-webcam';
 import { FaceLandmarker, FilesetResolver } from '@mediapipe/tasks-vision';
 
-// --- 설정 값 (이 값을 조절하여 가이드라인과 인식 민감도를 변경하세요) ---
+// --- 설정 값 (정사각형 UI에 맞게 재조정) ---
 const GUIDELINE_CONFIG = {
-  // 타원 가이드라인의 크기 조절 (값이 작을수록 가이드라인이 커집니다)
-  WIDTH_FACTOR: 4.8, // 캔버스 너비 대비 가이드라인의 가로 크기 비율
-  HEIGHT_FACTOR: 3.84, // 캔버스 높이 대비 가이드라인의 세로 크기 비율
-
-  // 얼굴 정렬 판정 민감도
-  // 얼굴 중심과 가이드라인 중심 사이의 최대 허용 거리 (px 단위, 작을수록 중앙에 더 정확히 위치해야 함)
-  MAX_CENTER_DISTANCE: 50,
-  // 얼굴 너비가 가이드라인 너비에 대해 차지하는 최소/최대 비율 (얼굴의 확대/축소 정도를 결정)
-  MIN_WIDTH_RATIO: 0.6, // 최소 60%
-  MAX_WIDTH_RATIO: 1.0, // 최대 100%
-  // 얼굴 높이가 가이드라인 높이에 대해 차지하는 최소/최대 비율
-  MIN_HEIGHT_RATIO: 0.6,
-  MAX_HEIGHT_RATIO: 1.0,
+  // 보이는 정사각형 영역(비디오 높이 기준)에 대한 원의 반지름 비율
+  RADIUS_FACTOR: 4, // 값이 클수록 원이 작아짐
+  // 얼굴이 가이드라인 안에 얼마나 채워져야 하는지에 대한 비율
+  MIN_FACE_SCALE: 0.6,
+  MAX_FACE_SCALE: 1.0,
+  // 얼굴이 중앙에서 얼마나 떨어져도 되는지에 대한 허용 오차 (보이는 영역 높이 기준)
+  CENTER_OFFSET_THRESHOLD: 0.1, // 10%
 };
 
 const FaceCapture = () => {
   const webcamRef = useRef<Webcam>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationFrameId = useRef<number | null>(null);
+  const faceLandmarker = useRef<FaceLandmarker | null>(null);
 
-  const [faceLandmarker, setFaceLandmarker] = useState<FaceLandmarker | null>(
-    null
-  );
   const [modelsLoaded, setModelsLoaded] = useState(false);
+  const [isWebcamReady, setIsWebcamReady] = useState(false);
+  const [debugInfo, setDebugInfo] = useState('');
   const [isFaceAligned, setIsFaceAligned] = useState(false);
   const [capturedImage, setCapturedImage] = useState<string | null>(null);
 
-  // 1. Initialize MediaPipe FaceLandmarker
+  // 1. MediaPipe FaceLandmarker 초기화
   useEffect(() => {
     const createFaceLandmarker = async () => {
-      const vision = await FilesetResolver.forVisionTasks(
-        '/models' // Path to the WASM files
-      );
-      const landmarker = await FaceLandmarker.createFromOptions(vision, {
-        baseOptions: {
-          modelAssetPath: '/models/face_landmarker.task',
-          delegate: 'GPU',
-        },
-        outputFaceBlendshapes: false,
-        runningMode: 'VIDEO',
-        numFaces: 1,
-      });
-      setFaceLandmarker(landmarker);
-      setModelsLoaded(true);
-      console.log('MediaPipe FaceLandmarker loaded successfully');
+      try {
+        const vision = await FilesetResolver.forVisionTasks('/models');
+        const landmarker = await FaceLandmarker.createFromOptions(vision, {
+          baseOptions: {
+            modelAssetPath: '/models/face_landmarker.task',
+            delegate: 'GPU',
+          },
+          runningMode: 'VIDEO',
+          numFaces: 1,
+        });
+        faceLandmarker.current = landmarker;
+        setModelsLoaded(true);
+        console.log('MediaPipe FaceLandmarker loaded successfully');
+      } catch (error) {
+        console.error('Failed to create FaceLandmarker:', error);
+      }
     };
     createFaceLandmarker();
+
+    return () => {
+      faceLandmarker.current?.close();
+    };
   }, []);
 
-  const predictWebcam = useCallback(async () => {
-    if (!faceLandmarker || !webcamRef.current?.video) {
-      animationFrameId.current = requestAnimationFrame(predictWebcam);
+  const predictWebcam = useCallback(() => {
+    if (
+      !webcamRef.current?.video ||
+      !canvasRef.current ||
+      !faceLandmarker.current
+    ) {
       return;
     }
 
     const video = webcamRef.current.video;
+    const canvas = canvasRef.current;
+
     if (video.readyState < 2) {
       animationFrameId.current = requestAnimationFrame(predictWebcam);
       return;
     }
 
-    const startTimeMs = performance.now();
-    const results = faceLandmarker.detectForVideo(video, startTimeMs);
+    const results = faceLandmarker.current.detectForVideo(
+      video,
+      performance.now()
+    );
+    const ctx = canvas.getContext('2d');
 
-    if (canvasRef.current) {
-      const ctx = canvasRef.current.getContext('2d');
-      if (ctx) {
-        ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+    if (ctx) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-        const centerX = canvasRef.current.width / 2;
-        const centerY = canvasRef.current.height / 2;
-        const radiusX = canvasRef.current.width / GUIDELINE_CONFIG.WIDTH_FACTOR;
-        const radiusY =
-          canvasRef.current.height / GUIDELINE_CONFIG.HEIGHT_FACTOR;
+      // --- 보이는 영역(정사각형)에 대한 계산 ---
+      const videoWidth = video.videoWidth;
+      const videoHeight = video.videoHeight;
 
-        let faceAligned = false;
-        if (results.faceLandmarks && results.faceLandmarks.length > 0) {
-          const landmarks = results.faceLandmarks[0];
-          const xs = landmarks.map((p) => p.x * video.videoWidth);
-          const ys = landmarks.map((p) => p.y * video.videoHeight);
-          const minX = Math.min(...xs);
-          const maxX = Math.max(...xs);
-          const minY = Math.min(...ys);
-          const maxY = Math.max(...ys);
+      // object-cover로 인해 보이는 정사각형 영역의 크기는 비디오의 높이와 같다.
+      const visibleSize = videoHeight;
+      // 좌우가 잘려나간 부분의 크기 (한쪽)
+      const offsetX = (videoWidth - visibleSize) / 2;
 
-          const faceWidth = maxX - minX;
-          const faceHeight = maxY - minY;
-          const faceCenterX = minX + faceWidth / 2;
-          const faceCenterY = minY + faceHeight / 2;
+      // 가이드라인 원의 반지름과 중심 좌표
+      const guidelineRadius = visibleSize / GUIDELINE_CONFIG.RADIUS_FACTOR;
+      const centerX = videoWidth / 2;
+      const centerY = videoHeight / 2;
 
+      let faceAligned = false;
+      if (results.faceLandmarks && results.faceLandmarks.length > 0) {
+        const landmarks = results.faceLandmarks[0];
+        const xs = landmarks.map((p) => p.x * videoWidth);
+        const ys = landmarks.map((p) => p.y * videoHeight);
+
+        const minX = Math.min(...xs);
+        const maxX = Math.max(...xs);
+        const minY = Math.min(...ys);
+        const maxY = Math.max(...ys);
+
+        const faceWidth = maxX - minX;
+        const faceHeight = maxY - minY;
+        const faceCenterX = minX + faceWidth / 2;
+        const faceCenterY = minY + faceHeight / 2;
+
+        // 1. 얼굴이 보이는 영역 안에 있는지 확인
+        if (faceCenterX > offsetX && faceCenterX < videoWidth - offsetX) {
+          // 2. 얼굴이 중앙에 있는지 확인
           const distance = Math.sqrt(
             Math.pow(faceCenterX - centerX, 2) +
               Math.pow(faceCenterY - centerY, 2)
           );
-          const widthRatio = faceWidth / (radiusX * 2);
-          const heightRatio = faceHeight / (radiusY * 2);
+          const maxDistance =
+            visibleSize * GUIDELINE_CONFIG.CENTER_OFFSET_THRESHOLD;
+
+          // 3. 얼굴 크기가 적절한지 확인
+          const faceScale =
+            (faceWidth + faceHeight) / 2 / (guidelineRadius * 2);
+
+          setDebugInfo(
+            `D: ${distance.toFixed(0)}/${maxDistance.toFixed(0)} | S: ${faceScale.toFixed(2)}`
+          );
 
           if (
-            distance < GUIDELINE_CONFIG.MAX_CENTER_DISTANCE &&
-            widthRatio > GUIDELINE_CONFIG.MIN_WIDTH_RATIO &&
-            widthRatio < GUIDELINE_CONFIG.MAX_WIDTH_RATIO &&
-            heightRatio > GUIDELINE_CONFIG.MIN_HEIGHT_RATIO &&
-            heightRatio < GUIDELINE_CONFIG.MAX_HEIGHT_RATIO
+            distance < maxDistance &&
+            faceScale > GUIDELINE_CONFIG.MIN_FACE_SCALE &&
+            faceScale < GUIDELINE_CONFIG.MAX_FACE_SCALE
           ) {
             faceAligned = true;
           }
+        } else {
+          setDebugInfo('얼굴이 중앙에 오도록 조절해주세요.');
         }
-        setIsFaceAligned(faceAligned);
-
-        ctx.save();
-        ctx.translate(canvasRef.current.width, 0);
-        ctx.scale(-1, 1);
-
-        ctx.beginPath();
-        ctx.strokeStyle = faceAligned ? '#4ade80' : '#f87171';
-        ctx.lineWidth = 6;
-        ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, 0, 2 * Math.PI);
-        ctx.stroke();
-
-        ctx.restore();
+      } else {
+        setDebugInfo('얼굴을 인식할 수 없습니다.');
       }
+      setIsFaceAligned(faceAligned);
+
+      // --- 가이드라인 그리기 ---
+      ctx.save();
+      // 비디오가 좌우 반전되어 있으므로 캔버스도 좌우 반전
+      ctx.translate(videoWidth, 0);
+      ctx.scale(-1, 1);
+
+      ctx.beginPath();
+      ctx.strokeStyle = faceAligned ? '#4ade80' : '#f87171';
+      ctx.lineWidth = 6;
+
+      // CSS 왜곡을 보정하기 위해 가로로 넓은 타원을 그린다.
+      const radiusY = guidelineRadius;
+      const radiusX = radiusY * (videoWidth / videoHeight); // 16:9 비율 적용
+      ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, 0, 2 * Math.PI);
+
+      ctx.stroke();
+      ctx.restore();
     }
 
     animationFrameId.current = requestAnimationFrame(predictWebcam);
-  }, [faceLandmarker]);
+  }, []);
 
-  const handleUserMedia = useCallback(() => {
-    if (animationFrameId.current) {
-      cancelAnimationFrame(animationFrameId.current);
+  // Master useEffect to start/stop detection
+  useEffect(() => {
+    if (modelsLoaded && isWebcamReady && !capturedImage) {
+      if (animationFrameId.current)
+        cancelAnimationFrame(animationFrameId.current);
+      animationFrameId.current = requestAnimationFrame(predictWebcam);
+    } else {
+      if (animationFrameId.current)
+        cancelAnimationFrame(animationFrameId.current);
     }
-    animationFrameId.current = requestAnimationFrame(predictWebcam);
-  }, [predictWebcam]);
+
+    return () => {
+      if (animationFrameId.current)
+        cancelAnimationFrame(animationFrameId.current);
+    };
+  }, [modelsLoaded, isWebcamReady, capturedImage, predictWebcam]);
 
   const handleCapture = () => {
     if (webcamRef.current) {
       const imageSrc = webcamRef.current.getScreenshot();
       setCapturedImage(imageSrc);
-      if (animationFrameId.current) {
-        cancelAnimationFrame(animationFrameId.current);
-      }
     }
   };
 
-  const handleRetake = () => {
-    setCapturedImage(null);
-    handleUserMedia();
-  };
+  const handleRetake = () => setCapturedImage(null);
 
   const handleUsePhoto = () => {
-    if (capturedImage) {
+    if (capturedImage)
       console.log('Using photo:', capturedImage.substring(0, 30) + '...');
-    }
   };
 
   return (
@@ -163,11 +199,13 @@ const FaceCapture = () => {
       <h2 className="mb-4 h-8 text-center text-2xl font-bold">
         {!modelsLoaded
           ? '얼굴 인식 모델을 불러오는 중...'
-          : capturedImage
-            ? '촬영된 사진'
-            : isFaceAligned
-              ? '준비 완료! 촬영 버튼을 누르세요.'
-              : '얼굴을 가이드라인에 맞춰주세요'}
+          : !isWebcamReady
+            ? '카메라를 준비하는 중...'
+            : capturedImage
+              ? '촬영된 사진'
+              : isFaceAligned
+                ? '준비 완료! 촬영 버튼을 누르세요.'
+                : '얼굴을 가이드라인에 맞춰주세요'}
       </h2>
       <div className="relative h-96 w-96 overflow-hidden rounded-lg shadow-lg">
         {capturedImage ? (
@@ -183,15 +221,18 @@ const FaceCapture = () => {
               audio={false}
               mirrored
               className="absolute z-10 h-full w-full object-cover"
-              onUserMedia={handleUserMedia}
+              onUserMedia={() => setIsWebcamReady(true)}
               videoConstraints={{ width: 1280, height: 720 }}
             />
             <canvas
               ref={canvasRef}
               className="absolute z-20 h-full w-full"
-              width="640"
-              height="480"
+              width={1280}
+              height={720}
             />
+            <div className="absolute bottom-2 left-2 z-30 rounded bg-black bg-opacity-50 p-2 font-mono text-xs text-white">
+              {debugInfo}
+            </div>
           </>
         )}
       </div>


### PR DESCRIPTION
개요

  이 PR은 FaceCapture 컴포넌트의 웹캠 해상도를 높이고, 정사각형 UI에서도 얼굴 인식이
  정확하게 동작하도록 개선합니다.

  배경

  기존에는 640x480 해상도에서만 얼굴 인식이 동작했습니다. 웹캠 해상도를 1280x720으로
  높이자, CSS(object-cover)로 인해 표시되는 정사각형 영역과 실제 16:9 영상 간의 좌표
  불일치 문제가 발생하여 얼굴 정렬이 불가능했습니다. 또한, 가이드라인이 세로로 찌그러져
  보이는 시각적 문제도 있었습니다.

  주요 변경 사항

   - 웹캠 해상도 상향: videoConstraints를 1280x720으로 변경하여 고화질 이미지를 캡처할 수
     있도록 했습니다.
   - 좌표 계산 로직 수정: CSS object-cover로 인해 좌우가 잘려나가는 부분을 고려하여,
     사용자가 보는 정사각형 영역을 기준으로 얼굴의 중심점과 크기를 계산하도록 로직을 전면
     수정했습니다.
   - 가이드라인 왜곡 보정: CSS에 의해 찌그러지는 비율을 역으로 계산하여, 코드상에서는
     가로로 넓은 타원(ellipse)을 그려 사용자에게는 완벽한 원으로 보이도록 수정했습니다.
   - 설정 값(Config) 재조정: 해상도에 종속적이지 않고, 보이는 영역을 기준으로 동적으로
     작동하도록 GUIDELINE_CONFIG 값을 재조정했습니다.