### PR TITLE
feat: 관리자 페이지 개발

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.85.5",
     "@toss/ky": "^1.2.1",
     "clsx": "^2.1.1",
+    "dayjs": "^1.11.18",
     "motion": "^12.23.12",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      dayjs:
+        specifier: ^1.11.18
+        version: 1.11.18
       motion:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -938,6 +941,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  dayjs@1.11.18:
+    resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -2391,6 +2397,8 @@ snapshots:
       which: 2.0.2
 
   csstype@3.1.3: {}
+
+  dayjs@1.11.18: {}
 
   debug@4.4.1:
     dependencies:

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -1,0 +1,33 @@
+import { http } from './http';
+import type { GenerationsResponse } from './types';
+
+interface GetGenerationsParams {
+  lastId?: number;
+  limit?: number;
+  status?: string; // 예: 필터링을 위한 파라미터
+}
+
+const adminApi = {
+  /**
+   * @description 관리자 페이지에서 세대 목록을 무한 스크롤로 가져옵니다.
+   * @param lastId 마지막으로 조회된 항목의 ID
+   * @param limit 한 페이지에 가져올 항목 수
+   */
+  getGenerations: ({ lastId, limit = 24, status }: GetGenerationsParams) => {
+    const searchParams = new URLSearchParams();
+    if (lastId) {
+      searchParams.append('lastId', String(lastId));
+    }
+    searchParams.append('limit', String(limit));
+    if (status) {
+      searchParams.append('status', status);
+    }
+
+    // http.ts에서 '/api'를 붙여주므로 '/admin/contents'가 맞습니다.
+    return http.get<GenerationsResponse>(
+      `/api/admin/contents?${searchParams.toString()}`
+    );
+  },
+};
+
+export default adminApi;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,7 +19,7 @@ export interface ApiResponse<T> {
 
 export interface KioskResult {
   imageUrl: string;
-  videoUrl:string;
+  videoUrl: string;
 }
 
 export type KeywordType = 'COLOR_AND_STYLE' | 'ATMOSPHERE_AND_MOOD';
@@ -59,4 +59,27 @@ export interface Content {
  */
 export interface ContentPresentedPayload {
   contentId: number;
+}
+
+export type SmsStatus = 'SENT' | 'FAILED' | 'PENDING' | 'NOT_FOUND';
+
+export type AdminContentStatus = 'PROCESSING' | 'COMPLETE' | 'FAILED';
+
+/**
+ * @description GET /api/admin/contents API의 응답 배열에 포함될 콘텐츠 객체의 타입입니다.
+ */
+export interface Generation {
+  contentId: number;
+  imageUrl?: string;
+  smsStatus: SmsStatus;
+  status: AdminContentStatus;
+  createdAt: string; // JSON으로 직렬화된 날짜는 string으로 받는 것이 안전합니다.
+}
+
+/**
+ * @description GET /api/admin/contents API의 응답 데이터 타입입니다. (무한 스크롤용)
+ */
+export interface GenerationsResponse {
+  list: Generation[];
+  count?: number; // 전체 항목 개수
 }

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,0 +1,65 @@
+import { Link, useLocation } from 'react-router-dom';
+import { ROUTER_PATH } from '../../router';
+import clsx from 'clsx';
+
+type CreditLabelProps = {
+  type: 'NEW' | 'AKL' | 'REP';
+};
+const CreditLabel = ({ type }: CreditLabelProps) => {
+  return (
+    <div className="h-7 px-3.5 py-1.5 bg-neutral-100 rounded-md outline outline-1 outline-offset-[-1px] outline-slate-200 inline-flex justify-start items-center gap-0.5">
+      <div className="justify-start text-neutral-600 text-xs font-medium font-['Pretendard'] leading-3">
+        {type}
+      </div>
+      <div className="justify-start text-blue-700 text-xs font-bold font-['Pretendard'] leading-3">
+        342
+      </div>
+    </div>
+  );
+};
+
+const AdminHeader = () => {
+  const location = useLocation();
+  const activeStyle = (router: string) => {
+    if (router === location.pathname || location.pathname.includes(router)) {
+      return 'text-black';
+    }
+    return 'text-[#c3c9ce]';
+  };
+  return (
+    <header className="stiky top-0 h-[var(--admin-header-height)] flex items-center justify-between px-[50px]">
+      <div className="flex items-center gap-13">
+        <span className="font-bold text-[20px] text-cxs-primary">
+          SIMULATED RUNWAY
+        </span>
+        <div className="inline-flex gap-5">
+          <Link
+            to={ROUTER_PATH.ADMIN_GENERATIONS}
+            className={clsx(
+              'text-[18px] font-semibold',
+              activeStyle(ROUTER_PATH.ADMIN_GENERATIONS)
+            )}
+          >
+            AI 생성
+          </Link>
+          <Link
+            to={ROUTER_PATH.ADMIN_VIDEOS}
+            className={clsx(
+              'text-[18px] font-semibold',
+              activeStyle(ROUTER_PATH.ADMIN_VIDEOS)
+            )}
+          >
+            영상 관리
+          </Link>
+        </div>
+      </div>
+      <div className="flex gap-1">
+        <CreditLabel type="NEW" />
+        <CreditLabel type="AKL" />
+        <CreditLabel type="REP" />
+      </div>
+    </header>
+  );
+};
+
+export default AdminHeader;

--- a/src/components/admin/GenerationListItem.tsx
+++ b/src/components/admin/GenerationListItem.tsx
@@ -1,0 +1,59 @@
+import {
+  normalizeAdminContentStatus,
+  getContentLabel,
+  normalizeSmsStatus,
+  getSmsLabel,
+} from '../../utils/admin/statusMapping';
+import AdminStatusLabel from '../ui/AdminStatusLabel';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+export type SmsStatus = 'SENT' | 'FAILED' | 'PENDING' | 'NOT_FOUND';
+
+export type AdminContentStatus = 'PROCESSING' | 'COMPLETE' | 'FAILED';
+interface GenerationsListItemType {
+  imageUrl?: string;
+  smsStatus: SmsStatus;
+  status: AdminContentStatus;
+  createdAt: Date;
+}
+
+const GenerationsListItem = ({
+  imageUrl,
+  smsStatus,
+  status,
+  createdAt,
+}: GenerationsListItemType) => {
+  dayjs.extend(utc);
+  dayjs.extend(timezone);
+
+  // 한국 시간대 적용
+  const formattedDate = dayjs(createdAt)
+    .tz('Asia/Seoul')
+    .format('YYYY.MM.DD HH:mm:ss');
+
+  return (
+    <div>
+      <div className="aspect-square rounded-[12px] bg-[#DCE2E6] border-1 border-[#E9E9E9] mb-3 overflow-hidden">
+        <img src={imageUrl} alt="" />
+      </div>
+      <div className="flex justify-between items-center">
+        <div className="flex gap-1">
+          {/* AI 생성 상태 */}
+          <AdminStatusLabel variant={normalizeAdminContentStatus(status)}>
+            {getContentLabel(status)}
+          </AdminStatusLabel>
+          {/* 문자 발송 상태 (smsStatus가 있을 경우에만 렌더링) */}
+          {
+            <AdminStatusLabel variant={normalizeSmsStatus(smsStatus)}>
+              {getSmsLabel(smsStatus)} {smsStatus}
+            </AdminStatusLabel>
+          }
+        </div>
+        <span className="text-[14px] text-[#c3c9ce]">{formattedDate}</span>
+      </div>
+    </div>
+  );
+};
+
+export default GenerationsListItem;

--- a/src/components/ui/AdminButton.tsx
+++ b/src/components/ui/AdminButton.tsx
@@ -1,0 +1,45 @@
+import clsx from 'clsx';
+import type { ButtonHTMLAttributes } from 'react';
+
+type AdminButton = {
+  variants?: 'primary' | 'secondary' | 'outline';
+  size?: 36 | 48 | 50;
+  clssName?: string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+const AdminButton = ({
+  variants = 'primary',
+  size = 36,
+  clssName,
+  ...rest
+}: AdminButton) => {
+  const variantsPalette = () => {
+    if (variants === 'outline') {
+      return 'border-1 border-black text-black';
+    } else if (variants === 'secondary') {
+      return 'bg-black text-white';
+    }
+    // primary
+    return 'bg-cxs-primary text-white';
+  };
+  const Size = () => {
+    if (size === 36) {
+      return 'h-[36px] text-[14px]';
+    } else if (size === 48) {
+      return 'h-[48px] text-[14px]';
+    }
+    return 'h-[50px]';
+  };
+  return (
+    <button
+      className={clsx(
+        'rounded-[8px] px-5',
+        variantsPalette(),
+        Size(),
+        clssName
+      )}
+      {...rest}
+    />
+  );
+};
+
+export default AdminButton;

--- a/src/components/ui/AdminStatusLabel.tsx
+++ b/src/components/ui/AdminStatusLabel.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export type AdminStatusLabelUiVariant =
+  | 'success'
+  | 'pending'
+  | 'failed'
+  | 'warning';
+
+const UI_STYLES: Record<AdminStatusLabelUiVariant, string> = {
+  success: 'bg-[#F1FFF3] border border-[#D2F5D9] text-[#1E7A46]',
+  pending: 'bg-[#F4F6F7] border border-[#E9EDF0] text-[#7A8893]',
+  failed: 'bg-[#FFF6F6] border border-[#FFE7E7] text-[#FF0E12]',
+  warning: 'bg-[#FFFBEA] border border-[#FFE8A3] text-[#8A6D1D]',
+};
+
+export interface AdminStatusLabelProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  /** 공통 UI 톤 (서버 상태를 정규화한 값) */
+  variant?: AdminStatusLabelUiVariant;
+}
+
+const AdminStatusLabel = ({
+  variant = 'pending',
+  className,
+  ...props
+}: AdminStatusLabelProps) => {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center font-medium text-[12px] rounded-[6px] h-6 px-2',
+        UI_STYLES[variant],
+        className
+      )}
+      {...props}
+    />
+  );
+};
+
+export default AdminStatusLabel;

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,27 @@
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css');
 @import 'tailwindcss';
 
+:root {
+}
+@theme {
+  --color-cxs-primary: #0033ff;
+  --admin-header-height: 64px;
+}
 body {
-  font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR',
-    'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+  font-family:
+    'Pretendard',
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    'Helvetica Neue',
+    'Segoe UI',
+    'Apple SD Gothic Neo',
+    'Noto Sans KR',
+    'Malgun Gothic',
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
     sans-serif;
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,11 +1,11 @@
 import { Outlet } from 'react-router-dom';
+import AdminHeader from '../components/admin/AdminHeader';
 
 const AdminPage = () => {
   return (
-    <div>
-      {/* TODO: 관리자 페이지 공통 레이아웃 (e.g., 사이드바, 헤더) */}
-      <h2>Admin Section</h2>
-      <main>
+    <div className="grid grid-rows-[var(--admin-header-height)_1fr] min-h-[100dvh] min-w-[1200px]">
+      <AdminHeader />
+      <main className="">
         <Outlet />
       </main>
     </div>
@@ -13,4 +13,3 @@ const AdminPage = () => {
 };
 
 export default AdminPage;
-

--- a/src/pages/admin/GenerationsListPage.tsx
+++ b/src/pages/admin/GenerationsListPage.tsx
@@ -1,8 +1,110 @@
+import { useInfiniteQuery, type InfiniteData } from '@tanstack/react-query';
+import GenerationsListItem from '../../components/admin/GenerationListItem';
+import AdminButton from '../../components/ui/AdminButton';
+import adminApi from '../../api/adminApi';
+import { Fragment, useRef, useCallback } from 'react';
+import type { GenerationsResponse } from '../../api/types';
+
 const GenerationsListPage = () => {
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+    isError,
+  } = useInfiniteQuery<
+    GenerationsResponse, // queryFn이 반환하는 데이터 타입
+    Error, // 에러 타입
+    InfiniteData<GenerationsResponse>, // select 함수 등으로 가공된 최종 데이터 타입
+    string[], // 쿼리 키 타입
+    number | undefined // pageParam 타입
+  >({
+    queryKey: ['generations'],
+    queryFn: ({ pageParam }) =>
+      adminApi.getGenerations({ lastId: pageParam, limit: 12 }),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => {
+      // 서버에서 받은 데이터가 limit(12)보다 적으면 마지막 페이지로 간주합니다.
+      if (lastPage.list.length < 12) {
+        return undefined;
+      }
+      const lastItem = lastPage.list[lastPage.list.length - 1];
+      return lastItem ? lastItem.contentId : undefined;
+    },
+  });
+
+  // Intersection Observer를 위한 설정
+  const observer = useRef<IntersectionObserver | null>(null);
+  const observerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (isFetchingNextPage) return;
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage) {
+          fetchNextPage();
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [isFetchingNextPage, hasNextPage, fetchNextPage]
+  );
+
+  if (isPending) {
+    return <p className="text-center">로딩 중...</p>;
+  }
+
+  if (isError) {
+    return <p className="text-center">에러가 발생했습니다: {error.message}</p>;
+  }
+
+  const allGenerations = data.pages.flatMap((page) => page.list);
+  const totalCount = data.pages[0]?.count ?? allGenerations.length;
+
   return (
-    <div>
-      <h1>AI 생성 리스트 페이지</h1>
-      {/* TODO: 리스트 구현 */}
+    <div className="w-[min(calc(100%-100px),1200px)] h-full mx-auto">
+      <div className="flex justify-between pb-6">
+        <div className="text-[20px] font-semibold">
+          <span>총 생성 수</span>
+          <span className="text-cxs-primary">({totalCount})</span>
+        </div>
+        <AdminButton>키워드 변경하기</AdminButton>
+      </div>
+
+      {allGenerations.length > 0 ? (
+        <div className="grid grid-cols-4 gap-[50px_20px]">
+          {data.pages.map((page, i) => (
+            <Fragment key={i}>
+              {page.list.map((item) => (
+                <GenerationsListItem
+                  key={item.contentId}
+                  status={item.status}
+                  smsStatus={item.smsStatus}
+                  imageUrl={item.imageUrl}
+                  createdAt={new Date(item.createdAt)}
+                />
+              ))}
+            </Fragment>
+          ))}
+        </div>
+      ) : (
+        <p className="text-center py-10">생성된 콘텐츠가 없습니다.</p>
+      )}
+
+      {/* 감시 대상 요소: 이 요소가 보이면 다음 페이지를 불러옵니다. */}
+      <div ref={observerRef} style={{ height: '1px' }} />
+
+      {/* 다음 페이지 로딩 중 인디케이터 */}
+      {isFetchingNextPage && (
+        <p className="text-center py-4">다음 목록을 불러오는 중...</p>
+      )}
+
+      {!hasNextPage && allGenerations.length > 0 && (
+        <p className="text-center py-4 text-gray-500">마지막 페이지입니다.</p>
+      )}
     </div>
   );
 };

--- a/src/utils/admin/statusMapping.ts
+++ b/src/utils/admin/statusMapping.ts
@@ -1,0 +1,48 @@
+/** ──────────────────────────────────────────────
+ *  1) 서버 타입 (import로 제공되는 것을 그대로 사용)
+ *  SmsStatus = 'SENT' | 'FAILED' | 'PENDING' | 'NOT_FOUND'
+ *  AdminContentStatus = 'PROCESSING' | 'COMPLETE' | 'FAILED'
+ *  ────────────────────────────────────────────── */
+
+import type {
+  AdminContentStatus,
+  SmsStatus,
+} from '../../components/admin/GenerationListItem';
+import type { AdminStatusLabelUiVariant } from '../../components/ui/AdminStatusLabel';
+
+/** 2) 공통 UI 토큰으로 정규화 (도메인별 매퍼) */
+const SMS_TO_UI = {
+  SENT: 'success',
+  FAILED: 'failed',
+  PENDING: 'pending',
+  NOT_FOUND: 'warning',
+} as const satisfies Record<SmsStatus, AdminStatusLabelUiVariant>;
+
+const CONTENT_TO_UI = {
+  PROCESSING: 'pending',
+  COMPLETE: 'success',
+  FAILED: 'failed',
+} as const satisfies Record<AdminContentStatus, AdminStatusLabelUiVariant>;
+
+export const normalizeSmsStatus = (s: SmsStatus): AdminStatusLabelUiVariant =>
+  SMS_TO_UI[s];
+export const normalizeAdminContentStatus = (
+  s: AdminContentStatus
+): AdminStatusLabelUiVariant => CONTENT_TO_UI[s];
+
+/** 3) 라벨 (도메인별) */
+const SMS_LABELS: Record<SmsStatus, string> = {
+  SENT: '발송완료',
+  FAILED: '발송실패',
+  PENDING: '발송대기',
+  NOT_FOUND: '대상없음',
+};
+
+const CONTENT_LABELS: Record<AdminContentStatus, string> = {
+  PROCESSING: '생성중',
+  COMPLETE: '생성완료',
+  FAILED: '생성실패',
+};
+
+export const getSmsLabel = (s: SmsStatus) => SMS_LABELS[s];
+export const getContentLabel = (s: AdminContentStatus) => CONTENT_LABELS[s];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,10 +12,6 @@ export default defineConfig({
         target: 'https://api.cxsctfair.com',
         changeOrigin: true,
       },
-      '/admin': {
-        target: 'https://api.cxsctfair.com',
-        changeOrigin: true,
-      },
     },
   },
 });


### PR DESCRIPTION
관리자 페이지의 생성 목록(GenerationsListPage)에 무한 스croll 기능을 구현했습니다.
- useInfiniteQuery를 사용하여 데이터를 효율적으로 로드합니다.
- Intersection Observer를 활용하여 스크롤 하단 감지 시 다음 페이지를 자동으로 불러옵니다.
- API 명세 변경에 따라 관련 타입 정의(types.ts)와 API 호출 함수(adminApi.ts)를 수정하고 추가했습니다.