### PR TITLE
fix: DisplayPage API 반복 호출 문제 해결

### DIFF
--- a/src/pages/DisplayPage.tsx
+++ b/src/pages/DisplayPage.tsx
@@ -29,6 +29,9 @@ const DisplayPage = () => {
   const { data: fixedPlaylist, isLoading } = useQuery({
     queryKey: ['fixedPlaylist'],
     queryFn: getFixedPlaylist,
+    refetchOnWindowFocus: false, // 창 포커스 시 재요청 방지
+    refetchOnReconnect: false, // 네트워크 재연결 시 재요청 방지
+    staleTime: Infinity, // 데이터를 항상 최신 상태로 간주
   });
 
   const { mutate: reportPresented } = useMutation({


### PR DESCRIPTION
- DisplayPage에서 getFixedPlaylist API가 불필요하게 반복 호출되던 문제 수정
- useQuery 옵션(refetchOnWindowFocus, refetchOnReconnect, staleTime)을 조정하여 API가 마운트 시에만 호출되도록 변경