### PR TITLE
release

### DIFF
--- a/src/components/dialogs/Confirm.tsx
+++ b/src/components/dialogs/Confirm.tsx
@@ -84,18 +84,21 @@ const KioskFormConfirmContent = (props: ConfirmContentProps) => {
       <p
         id="confirm-message"
         className="mt-2 text-[40px] text-[#0033ff] text-center whitespace-pre-wrap font-semibold leading-[1.3] pb-[50px]"
+        style={{ userSelect: 'none' }}
       >
         {message}
       </p>
       <div className="flex justify-end gap-4">
         <button
           className="w-[284px] h-[100px] border-[3px] rounded-[20px] border-[#0033ff] font-bold text-[30px] text-[#0033ff] active:scale-95 duration-100"
+          style={{ userSelect: 'none' }}
           onClick={handleCancel}
         >
           {cancelButtonText}
         </button>
         <button
           className="w-[284px] h-[100px] border-[3px] rounded-[20px] border-[#0033ff] font-bold text-[30px] text-white bg-[#0033ff] active:scale-95 duration-100"
+          style={{ userSelect: 'none' }}
           ref={confirmButtonRef}
           onClick={handleConfirm}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,9 @@ body {
   display: none;
 }
 
+#kiosk-container * {
+  user-select: none;
+}
 /* react-layered-dialog 스크롤 잠금 */
 body:has([data-scroll-lock='true']) {
   overflow: hidden;


### PR DESCRIPTION
[feat: kiosk-container 아래 요소 user-select : none.처리](https://github.com/seunjin/cxs-ctfair-2025-frontend/commit/903d3522cc9e987edaa62385a00fc4368ea8a15b)
@[seunjin](https://github.com/seunjin/cxs-ctfair-2025-frontend/commits?author=seunjin)
[feat: KioskFormConfirmContent의 버튼, 텍스트 아래 요소 user-select : none.처리](https://github.com/seunjin/cxs-ctfair-2025-frontend/commit/f9f8e1c5327c3ca87f3fd7c18f8baaa3f40f2229)
@[seunjin](https://github.com/seunjin/cxs-ctfair-2025-frontend/commits?author=seunjin)